### PR TITLE
Check if erro is invalid grant then refresh token

### DIFF
--- a/src/service/googleOauth.ts
+++ b/src/service/googleOauth.ts
@@ -1,6 +1,6 @@
 "use server";
 
-import * as google from "googleapis";   
+import * as google from "googleapis";
 const OAuth2 = google.Auth.OAuth2Client;
 
 export const getGoogleAccessToken = async () => {
@@ -11,25 +11,39 @@ export const getGoogleAccessToken = async () => {
   );
 
   oauth2Client.setCredentials({
+    access_token: process.env.GCP_ACCESS_TOKEN,
     refresh_token: process.env.GCP_REFRESH_TOKEN,
     scope: "https://mail.google.com/",
   });
 
-//   const accessToken = (await oauth2Client.getAccessToken()).token;
+  //   const accessToken = (await oauth2Client.getAccessToken()).token;
 
-    const accessToken = await new Promise((resolve, reject) => {
-      oauth2Client.getAccessToken((err, token) => {
-        if (err) {
-          console.error("*ERR: ", err);
-          reject(err);
+  const accessToken = await new Promise((resolve, reject) => {
+    oauth2Client.getAccessToken((err, token) => {
+      if (err) {
+        console.error("*ERR: ", err);
+        console.error("*ERR_MESSAGE: ", err?.message);
+        if (
+          err?.message === "invalid_grant"
+        ) {
+          console.log("Refresh Access Token");
+
+          const res = oauth2Client.refreshAccessToken();
+          res.then(refreshRes => {
+            oauth2Client.setCredentials(refreshRes.credentials);
+            // return refreshRes.credentials.access_token;
+            resolve(refreshRes.credentials.access_token)
+          })
         }
-        resolve(token);
-      });
+        reject(err);
+      }
+      resolve(token);
     });
+  });
 
-    if (typeof accessToken === 'string') {
-        return accessToken
-    } else {
-        throw new Error("Google getAcessToken failed!");
-    }
+  if (typeof accessToken === "string") {
+    return accessToken;
+  } else {
+    throw new Error("Google getAcessToken failed!");
+  }
 };


### PR DESCRIPTION
# Refresh Token

Email service implements validation to check if erro is invalid grant then reshesh token, because emailt service current don't auto refresh token and receive error message.

Send email not working.

## Code updated
```ts
    oauth2Client.getAccessToken((err, token) => {
        if (err) {
          console.error("*ERR: ", err);
          console.error("*ERR_MESSAGE: ", err?.message);
          if (
            err?.message === "invalid_grant"
          ) {
            console.log("Refresh Access Token");
  
            const res = oauth2Client.refreshAccessToken();
            res.then(refreshRes => {
              oauth2Client.setCredentials(refreshRes.credentials);
              // return refreshRes.credentials.access_token;
              resolve(refreshRes.credentials.access_token)
            })
          }
          reject(err);
        }
        resolve(token);
    });
```